### PR TITLE
增加 HTTP 请求超时

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/EhApplication.java
+++ b/app/src/main/java/com/hippo/ehviewer/EhApplication.java
@@ -132,9 +132,10 @@ public class EhApplication extends RecordingApplication {
         EhApplication application = ((EhApplication) context.getApplicationContext());
         if (application.mOkHttpClient == null) {
             application.mOkHttpClient = new OkHttpClient.Builder()
-                    .connectTimeout(10, TimeUnit.SECONDS)
-                    .readTimeout(10, TimeUnit.SECONDS)
-                    .writeTimeout(10, TimeUnit.SECONDS)
+                    .connectTimeout(5, TimeUnit.SECONDS)
+                    .readTimeout(5, TimeUnit.SECONDS)
+                    .writeTimeout(5, TimeUnit.SECONDS)
+                    .callTimeout(10, TimeUnit.SECONDS)
                     .cookieJar(getEhCookieStore(application))
                     .dns(new EhDns(application))
                     .proxySelector(getEhProxySelector(application))

--- a/app/src/main/java/com/hippo/ehviewer/spider/SpiderQueen.java
+++ b/app/src/main/java/com/hippo/ehviewer/spider/SpiderQueen.java
@@ -1219,7 +1219,10 @@ public final class SpiderQueen implements Runnable {
                         Log.d(TAG, "Start download image " + index);
                     }
 
-                    Call call = mHttpClient.newCall(new EhRequestBuilder(targetImageUrl, referer).build());
+                    // disable Call Timeout for image-downloading requests
+                    Call call = mHttpClient.newBuilder()
+                            .callTimeout(0, TimeUnit.SECONDS).build()
+                            .newCall(new EhRequestBuilder(targetImageUrl, referer).build());
                     Response response = call.execute();
                     ResponseBody responseBody = response.body();
 


### PR DESCRIPTION
有时候使用一段时间之后会卡住，一直转圈圈，特别是在缩略图预览页面。猜测可能是网络问题或者 EH API 阻塞了。

这个 PR 调整了 TCP 的 connect read write 超时，并且设置了 callTimeout 为 10s，从 client 发出请求开始，如果 10s 之内没有返回结果，也会超时。图片下载不受这个限制，只对 API 请求生效。

自己使用了一下好像是解决了，但是本人没有安卓开发经验，不知道能不能解决问题，但是加个超时总是没有错的。